### PR TITLE
Docstring typo or oversight.

### DIFF
--- a/src/decorate.clj
+++ b/src/decorate.clj
@@ -10,7 +10,7 @@
   "Macros for redefining functions with decorators.")
 
 (defmacro redef
-  "Redefine an existing value, keeping the metadata intact."
+  "Redefine an existing var, keeping the metadata intact."
   [name value]
   `(let [m# (meta #'~name)
          v# (def ~name ~value)]


### PR DESCRIPTION
 Hello James, 

I think you didn't mean value in the docstring of `redef`. You're redefining a var.

I was studying these macros for educational purposes. PRs like these may be a bit pedantic. Sorry for that.

Lovely library BTW.
